### PR TITLE
ENG-2319 Create a release we can download

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,4 +1,4 @@
-name: codesee-deps-dotnet package
+name: Build and Test
 
 on: [push]
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,4 +1,4 @@
-name: codesee-deps-dotnet release
+name: Release
 
 on: 
   push:


### PR DESCRIPTION
## What changed
Added a release workflow.  It is tag based, so creating a v* tag will cause it to run.


## Why are we making this change
We need to publish the artifact of the build so that we can download it from out action.


## How was the change implemented, and why was it implemented in this way
Tag based release.  If someone hates that we could do it on push to main.  I didn't want a ton of artifacts out there, so tags seemed a more deliberate means of releasing.

## How was the change tested
Not yet.


## Screenshots of any frontend changes