### PR TITLE
Cleanup null checks

### DIFF
--- a/Disassembler/AssemblyLoader.cs
+++ b/Disassembler/AssemblyLoader.cs
@@ -37,7 +37,15 @@ namespace Disassembler
 
         public AssemblyLoader(string assemblyPath) {
             this.assemblyPath = assemblyPath;
-            context = new LocalFolderLoadContext(Path.GetDirectoryName(assemblyPath));
+            var assemDir = Path.GetDirectoryName(assemblyPath);
+            if (assemDir != null)
+            {
+                context = new LocalFolderLoadContext(assemDir);
+            }
+            else
+            {
+                throw new Exception("Unexpected null getting assembly directory.");
+            }
         }
 
         public Assembly? Load()

--- a/Disassembler/CompiledFileLocator.cs
+++ b/Disassembler/CompiledFileLocator.cs
@@ -53,9 +53,9 @@ namespace Disassembler
                     }
                 }
             }
-            catch (Exception ex)
+            catch (Exception)
             {
-
+                //ignore
             }
             return result;
         }

--- a/DotNETDepends/Dependencies.cs
+++ b/DotNETDepends/Dependencies.cs
@@ -100,7 +100,7 @@ namespace DotNETDepends
                 {
                     foreach (var typeRef in type.TypeReferences)
                     {
-                        if (typeRef.Name.Equals(symbol.Name) && typeRef.Namespace.Equals(symbol.Namespace))
+                        if (typeRef.Name.Equals(symbol.Name) && symbol.Namespace.Equals(typeRef.Namespace))
                         {
                             result.Add(type);
                             break;

--- a/DotNETDepends/PublishedWebProject.cs
+++ b/DotNETDepends/PublishedWebProject.cs
@@ -40,10 +40,14 @@ namespace DotNETDepends
         private List<string> GetSourceFiles()
         {
             var result = new List<string>();
-            var dirInfo = new DirectoryInfo(Path.GetDirectoryName(project.FilePath));
-            AddFilesToList(result, dirInfo.GetFiles("*.cshtml", SearchOption.AllDirectories));
-            AddFilesToList(result, dirInfo.GetFiles("*.vbhtml", SearchOption.AllDirectories));
-            AddFilesToList(result, dirInfo.GetFiles("*.razor", SearchOption.AllDirectories));
+            var dir = Path.GetDirectoryName(project.FilePath);
+            if (dir != null)
+            {
+                var dirInfo = new DirectoryInfo(dir);
+                AddFilesToList(result, dirInfo.GetFiles("*.cshtml", SearchOption.AllDirectories));
+                AddFilesToList(result, dirInfo.GetFiles("*.vbhtml", SearchOption.AllDirectories));
+                AddFilesToList(result, dirInfo.GetFiles("*.razor", SearchOption.AllDirectories));
+            }
             return result;
         }
 
@@ -105,7 +109,7 @@ namespace DotNETDepends
         {
             if (project.FilePath != null && assemblyName != null)
             {
-                var binRoot = Path.Combine(new string[] { Path.GetDirectoryName(project.FilePath), "bin", config });
+                var binRoot = Path.Combine(new string[] { Path.GetDirectoryName(project.FilePath)?? "", "bin", config });
                 DirectoryInfo dirInfo = new(binRoot);
                 var dirs = dirInfo.GetDirectories();
                 string? assemPath = null;

--- a/DotNETDepends/RoslynProject.cs
+++ b/DotNETDepends/RoslynProject.cs
@@ -41,19 +41,20 @@ namespace DotNETDepends
         protected readonly Project project;
         private readonly IErrorReporter errorReporter;
         private readonly Dependencies dependencies;
-        private readonly string solutionRoot;
+        private readonly string? solutionRoot;
         public RoslynProject(Project project, Dependencies dependencies, IErrorReporter errorReporter)
         {
             this.project = project;
             this.dependencies = dependencies;
             this.errorReporter = errorReporter;
             solutionRoot = Path.GetDirectoryName(project.Solution.FilePath);
+
         }
 
         public async Task Analyze()
         {
             var compilation = await project.GetCompilationAsync().ConfigureAwait(false);
-            if (compilation != null)
+            if (compilation != null && solutionRoot != null)
             {
 
                 foreach (var tree in compilation.SyntaxTrees)

--- a/DotNETDepends/SolutionReader.cs
+++ b/DotNETDepends/SolutionReader.cs
@@ -211,21 +211,25 @@ namespace DotNETDepends
         {
             if (project.FilePath != null)
             {
-                var dirInfo = new DirectoryInfo(Path.GetDirectoryName(project.FilePath));
-                var cshtml = dirInfo.GetFiles("*.cshtml", SearchOption.AllDirectories);
-                if (cshtml.Length > 0)
+                var projDir = Path.GetDirectoryName(project.FilePath);
+                if (projDir != null)
                 {
-                    return true;
-                }
-                var vbhtml = dirInfo.GetFiles("*.vbhtml", SearchOption.AllDirectories);
-                if (vbhtml.Length > 0)
-                {
-                    return true;
-                }
-                var razor = dirInfo.GetFiles("*.razor", SearchOption.AllDirectories);
-                if (razor.Length > 0)
-                {
-                    return true;
+                    var dirInfo = new DirectoryInfo(projDir);
+                    var cshtml = dirInfo.GetFiles("*.cshtml", SearchOption.AllDirectories);
+                    if (cshtml.Length > 0)
+                    {
+                        return true;
+                    }
+                    var vbhtml = dirInfo.GetFiles("*.vbhtml", SearchOption.AllDirectories);
+                    if (vbhtml.Length > 0)
+                    {
+                        return true;
+                    }
+                    var razor = dirInfo.GetFiles("*.razor", SearchOption.AllDirectories);
+                    if (razor.Length > 0)
+                    {
+                        return true;
+                    }
                 }
             }
             return false;

--- a/DotNETDepends/SourceTypeBuilderFactory.cs
+++ b/DotNETDepends/SourceTypeBuilderFactory.cs
@@ -79,7 +79,7 @@ namespace DotNETDepends
             {
                 return null;
             }
-            return FindNamespaceFromViewImports(Path.GetDirectoryName(startDir), projectDir, importFileName, importFileExtension, out typeRoot);
+            return FindNamespaceFromViewImports(Path.GetDirectoryName(startDir) ?? "", projectDir, importFileName, importFileExtension, out typeRoot);
 
         }
         /*
@@ -89,28 +89,30 @@ namespace DotNETDepends
         {
             var relativePath = Path.GetRelativePath(projectDir, path);
             relativePath = Path.GetDirectoryName(relativePath);
-            if (relativePath.StartsWith(Path.DirectorySeparatorChar))
+            if (relativePath != null)
             {
-                relativePath = relativePath.Substring(1);
-            }
-            if (relativePath.EndsWith(Path.DirectorySeparatorChar))
-            {
-                relativePath = relativePath[..^1];
-            }
-            relativePath = relativePath.Replace(Path.DirectorySeparatorChar, '.');
-            if (rootNamespace != null && rootNamespace.Length != 0)
-            {
-                if (relativePath.Length > 0)
+                if (relativePath.StartsWith(Path.DirectorySeparatorChar))
                 {
-                    return rootNamespace + "." + relativePath;
+                    relativePath = relativePath.Substring(1);
                 }
-                else
+                if (relativePath.EndsWith(Path.DirectorySeparatorChar))
                 {
-                    return rootNamespace;
+                    relativePath = relativePath[..^1];
+                }
+                relativePath = relativePath.Replace(Path.DirectorySeparatorChar, '.');
+                if (rootNamespace != null && rootNamespace.Length != 0)
+                {
+                    if (relativePath.Length > 0)
+                    {
+                        return rootNamespace + "." + relativePath;
+                    }
+                    else
+                    {
+                        return rootNamespace;
+                    }
                 }
             }
-
-            return relativePath;
+            return relativePath ?? "";
         }
     }
 
@@ -124,7 +126,7 @@ namespace DotNETDepends
             var ns = ReadNamespaceFromFile(filePath);
             if (ns == null)
             {
-                ns = FindNamespaceFromViewImports(Path.GetDirectoryName(filePath), projectDir, "_Imports", ".razor", out string? typeRoot);
+                ns = FindNamespaceFromViewImports(Path.GetDirectoryName(filePath) ?? "", projectDir, "_Imports", ".razor", out string? typeRoot);
                 ns = DetermineNamespaceFromPath(filePath, ns ?? rootNamespace, typeRoot ?? projectDir);
             }
             ns ??= "";
@@ -145,7 +147,7 @@ namespace DotNETDepends
             var ns = ReadNamespaceFromFile(filePath);
             if (ns == null)
             {
-                ns = FindNamespaceFromViewImports(Path.GetDirectoryName(filePath), projectDir, "_ViewImports", Path.GetExtension(filePath), out string? typeRoot);
+                ns = FindNamespaceFromViewImports(Path.GetDirectoryName(filePath) ?? "", projectDir, "_ViewImports", Path.GetExtension(filePath), out string? typeRoot);
                 ns = DetermineNamespaceFromPath(filePath, ns ?? rootNamespace, typeRoot ?? projectDir);
             }
             ns ??= "";
@@ -160,15 +162,19 @@ namespace DotNETDepends
         {
             var relativeFile = Path.GetRelativePath(projectDir, filePath);
             var relativeDir = Path.GetDirectoryName(relativeFile);
-            if (relativeDir.StartsWith(Path.DirectorySeparatorChar))
+            if (relativeDir != null)
             {
-                relativeDir = relativeDir.Substring(1);
+                if (relativeDir.StartsWith(Path.DirectorySeparatorChar))
+                {
+                    relativeDir = relativeDir.Substring(1);
+                }
+                if (relativeDir.EndsWith(Path.DirectorySeparatorChar))
+                {
+                    relativeDir = relativeDir[..^1];
+                }
+                return relativeDir.Replace(Path.DirectorySeparatorChar, '_') + "_" + Path.GetFileNameWithoutExtension(filePath);
             }
-            if (relativeDir.EndsWith(Path.DirectorySeparatorChar))
-            {
-                relativeDir = relativeDir[..^1];
-            }
-            return relativeDir.Replace(Path.DirectorySeparatorChar, '_') + "_" + Path.GetFileNameWithoutExtension(filePath);
+            return "";
         }
     }
     internal class SourceTypeBuilderFactory

--- a/TestDependencyReading/TestUtils.cs
+++ b/TestDependencyReading/TestUtils.cs
@@ -8,13 +8,19 @@ namespace TestDependencyReading
 {
     internal class TestUtils
     {
-        public static string? GetFixturesPath()
+        public static string GetFixturesPath()
         {
-            string workingDir =  Path.Combine(Path.GetDirectoryName(System.Reflection.Assembly.GetExecutingAssembly().Location));
-            while(workingDir != null && !workingDir.EndsWith("TestDependencyReading")) {
-                workingDir= Path.GetDirectoryName(workingDir);
+            var assembly = System.Reflection.Assembly.GetExecutingAssembly();
+            if (assembly != null && assembly.Location != null)
+            {
+                string? workingDir = Path.GetDirectoryName(assembly.Location);
+                while (workingDir != null && !workingDir.EndsWith("TestDependencyReading"))
+                {
+                    workingDir = Path.GetDirectoryName(workingDir);
+                }
+                return Path.Combine(workingDir ?? "", "Fixtures");
             }
-            return Path.Combine(workingDir, "Fixtures");
+            throw new Exception("Unable to determine fixture directory.");
         }
     }
 }


### PR DESCRIPTION
## What changed
Cleanup of null dereference warnings.  These were harmless but made code reviews bad due to them showing up in the change set.

## Why are we making this change
Code hygiene. 


## How was the change implemented, and why was it implemented in this way
Basic null checks.


## How was the change tested
Unit tests.


## Screenshots of any frontend changes