### PR TITLE
Add a --version switch

### DIFF
--- a/DotNETDepends/Program.cs
+++ b/DotNETDepends/Program.cs
@@ -20,6 +20,12 @@ class Program
     {
         if (args.Length == 1 && File.Exists(args[0]))
         {
+            if ("--version".Equals(args[0]))
+            {
+                PrintVersion();
+                Environment.Exit(0);
+                return;
+            }
             if (!ValidateFileNameInput(args[0]))
             {
                 throw new Exception("Invalid command line argument.");
@@ -52,8 +58,12 @@ class Program
         }
 
     }
-
-    private static bool validateFileNameInput(string v)
+    private static void PrintVersion()
+    {
+        //!!When you change this version be sure to update the expected version in dot-net.ts in the codesee repo!!
+        Console.WriteLine("0.1.0");
+    }
+    private static bool ValidateFileNameInput(string v)
     {
         throw new NotImplementedException();
     }

--- a/DotNETDepends/Program.cs
+++ b/DotNETDepends/Program.cs
@@ -63,8 +63,4 @@ class Program
         //!!When you change this version be sure to update the expected version in dot-net.ts in the codesee repo!!
         Console.WriteLine("0.1.0");
     }
-    private static bool ValidateFileNameInput(string v)
-    {
-        throw new NotImplementedException();
-    }
 }


### PR DESCRIPTION
## What changed
Added a --version switch to print out a version number.


## Why are we making this change
The existing integration checks the version of the tool installed.


## How was the change implemented, and why was it implemented in this way
Just a check of arg[0] for version


## How was the change tested
Manually


## Screenshots of any frontend changes
NA