### PR TITLE
Change case on To and From to match Link in domain

### DIFF
--- a/DotNETDepends/Output/AnalysisOutput.cs
+++ b/DotNETDepends/Output/AnalysisOutput.cs
@@ -7,11 +7,14 @@ namespace DotNETDepends.Output
     {
         public Link(string from, string to)
         {
-            From = from;
-            To = to;
+            this.from = from;
+            this.to = to;
         }
-        public string From { get; set; }
-        public string To { get; set; }
+        //When from and to are deserialized by Node, it expects lower case
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Style", "IDE1006:Naming Styles", Justification = "Compatibility")]
+        public string from { get; set; }
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Style", "IDE1006:Naming Styles", Justification = "Compatibility")]
+        public string to { get; set; }
     }
 
     public class AnalysisOutput : IErrorReporter

--- a/TestDependencyReading/DependencyReaderTests.cs
+++ b/TestDependencyReading/DependencyReaderTests.cs
@@ -12,15 +12,15 @@ namespace TestDependencyReading
         {
             foreach (var link in found)
             {
-                expected.TryGetValue(link.From, out var expectedTo);
+                expected.TryGetValue(link.from, out var expectedTo);
                 Assert.IsNotNull(expectedTo);
-                Assert.AreEqual(expectedTo, link.To);
+                Assert.AreEqual(expectedTo, link.to);
             }
         }
 
         private bool LinkMatches(string from, string to, Link link)
         {
-            return link.To.Equals(FixPath(to)) && link.From.Equals(FixPath(from));
+            return link.to.Equals(FixPath(to)) && link.from.Equals(FixPath(from));
         }
 
         string FixPath(string path)


### PR DESCRIPTION
## What changed
In domain, the Link object that is used to deserialize this tool's output expects lower case to and from.  C#'s style is upper case.


## Why are we making this change
Compatibility with the Node object used to deserialize this off the console output.


## How was the change implemented, and why was it implemented in this way
Changed the names and references to them.  Added an attribute to block the style warning from the C# tools.


## How was the change tested
Unit test.  Not yet tested E2E with domain.


## Screenshots of any frontend changes