### PR TITLE
Add an osx-x64 build and artifact

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,14 +22,19 @@ jobs:
           dotnet-quality: 'ga'
       - name: Restore
         run: dotnet restore
-      - name: Publish
-        run: dotnet publish ./DotNETDepends/DotNETDepends.csproj --framework ${{ env.NET_VERSION }} --runtime linux-x64 --self-contained false --configuration Release -o output
+      - name: Publish Linux
+        run: dotnet publish ./DotNETDepends/DotNETDepends.csproj --framework ${{ env.NET_VERSION }} --runtime linux-x64 --self-contained false --configuration Release -o ./output
+      - name: Publish MacOS
+        run: dotnet publish ./DotNETDepends/DotNETDepends.csproj --framework ${{ env.NET_VERSION }} --runtime osx-x64 --self-contained false --configuration Release -o ./osx/output
       - name: Run Tests
         run: dotnet test
-      - name: Archive Release
+      - name: Archive Linux x64 Release
         run: tar -zcvf dotnetdepends.tar.gz ./output/
+      - name: Archive OSX x64 Release
+        run: tar -zcvf dotnetdepends-osx-x64.tar.gz ./osx/output/
       - name: Create Release
         uses: ncipollo/release-action@v1
         with:
-          artifacts: "dotnetdepends.tar.gz"
+          artifacts: "dotnetdepends.tar.gz,dotnetdepends-osx-x64.tar.gz"
+          artifactErrorsFailBuild: true
 


### PR DESCRIPTION
## What changed
Added an OSX x64 build to the release.


## Why are we making this change
It is needed to be able to run a local test of the tool in development.


## How was the change implemented, and why was it implemented in this way
Just a new build and tar file.


## How was the change tested
Was not.


## Screenshots of any frontend changes