### PR TITLE
Remove top level check assuming arg[0] is a File

### DIFF
--- a/DotNETDepends/Program.cs
+++ b/DotNETDepends/Program.cs
@@ -18,7 +18,7 @@ class Program
      */
     static async Task Main(string[] args)
     {
-        if (args.Length == 1 && File.Exists(args[0]))
+        if (args.Length == 1)
         {
             if ("--version".Equals(args[0]))
             {


### PR DESCRIPTION
## What changed
Removed top level check assuming arg[0] is a File


## Why are we making this change
It was never hitting the --version switch because --version is not a file


## How was the change implemented, and why was it implemented in this way
Just removed the File.exists check, which was already being checked later.


## How was the change tested
Locally, manually


## Screenshots of any frontend changes