### PR TITLE
Added some output during processing, added a win-x64 build

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,15 +26,19 @@ jobs:
         run: dotnet publish ./DotNETDepends/DotNETDepends.csproj --framework ${{ env.NET_VERSION }} --runtime linux-x64 --self-contained false --configuration Release -o ./output
       - name: Publish MacOS
         run: dotnet publish ./DotNETDepends/DotNETDepends.csproj --framework ${{ env.NET_VERSION }} --runtime osx-x64 --self-contained false --configuration Release -o ./osx/output
+      - name: Publish Windows x64
+        run: dotnet publish ./DotNETDepends/DotNETDepends.csproj --framework ${{ env.NET_VERSION }} --runtime win-x64 --self-contained false --configuration Release -o ./win/output
       - name: Run Tests
         run: dotnet test
       - name: Archive Linux x64 Release
         run: tar -zcvf dotnetdepends.tar.gz ./output/
       - name: Archive OSX x64 Release
         run: tar -zcvf dotnetdepends-osx-x64.tar.gz ./osx/output/
+      - name: Archive OSX x64 Release
+        run: tar -zcvf dotnetdepends-win-x64.tar.gz ./win/output/
       - name: Create Release
         uses: ncipollo/release-action@v1
         with:
-          artifacts: "dotnetdepends.tar.gz,dotnetdepends-osx-x64.tar.gz"
+          artifacts: "dotnetdepends.tar.gz,dotnetdepends-osx-x64.tar.gz,dotnetdepends-win-x64.tar.gz"
           artifactErrorsFailBuild: true
 

--- a/DotNETDepends/SolutionReader.cs
+++ b/DotNETDepends/SolutionReader.cs
@@ -35,7 +35,7 @@ namespace DotNETDepends
          */
         public async Task ReadSolutionAsync(String path, AnalysisOutput output)
         {
-            
+            Console.WriteLine("Reading solution: " + path);
             var workspace = MSBuildWorkspace.Create();
             var solution = await workspace.OpenSolutionAsync(path).ConfigureAwait(false);
             
@@ -171,6 +171,7 @@ namespace DotNETDepends
             var dotnetPath = SDKTools.GetDotnetPath();
             if (solution.FilePath != null)
             {
+                Console.WriteLine("Publishing Solution: " + solution.FilePath);
                 try
                 {
                     var startInfo = new ProcessStartInfo(dotnetPath)
@@ -252,6 +253,7 @@ namespace DotNETDepends
             var solutionRoot = Path.GetDirectoryName(solution.FilePath);
             if (project != null && project.FilePath != null && solutionRoot != null)
             {
+                Console.WriteLine("Processing project: " + project.FilePath);
                 var depEntry = dependencies.CreateProjectEntry(Path.GetRelativePath(solutionRoot, project.FilePath));
 
                 var projectDependencies = depGraph.GetProjectsThatThisProjectDirectlyDependsOn(projectId);
@@ -282,7 +284,7 @@ namespace DotNETDepends
                     }
                     else
                     {
-                        analysisOutput.AddErrorMessage("Found unsupported SDK in project: " + project.Name + " sdk: " + pubProject.SDK ?? "null");
+                        Console.WriteLine("Analizing web project with Rosalyn: " + project.FilePath);
                         //Just do the Roslyn analysis
                         await pubProject.Analyze();
                     }


### PR DESCRIPTION
## What changed
Add console logging as the app processes projects so we can see some output while running.
Created a win-x64 build.

## Why are we making this change
I'm troubleshooting a customer this afternoon, and this will be helpful.  I can have him run the Windows build locally on their repository.  Also we can tell if the hang is happening during the --version call or the processing of the projects.

## How was the change implemented, and why was it implemented in this way
Just logging and a new step to publish the windows build.

## How was the change tested
Ran it locally, unit tests

## Screenshots of any frontend changes
NA