### PR TITLE
Memory and performance improvements

### DIFF
--- a/DotNETDepends/Dependencies.cs
+++ b/DotNETDepends/Dependencies.cs
@@ -25,13 +25,9 @@ namespace DotNETDepends
             return dependency;
         }
 
-        public DependencyEntry CreateCodeFileEntry(string filePath, SemanticModel semantic, SyntaxTree tree)
+        public DependencyEntry CreateCodeFileEntry(string filePath)
         {
-            var dependency = new DependencyEntry(filePath, EntryType.File)
-            {
-                Semantic = semantic,
-                Tree = tree
-            };
+            var dependency = new DependencyEntry(filePath, EntryType.File);
             entries[filePath] = dependency;
             return dependency;
         }

--- a/DotNETDepends/DependencyEntry.cs
+++ b/DotNETDepends/DependencyEntry.cs
@@ -1,9 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using Microsoft.CodeAnalysis;
+﻿using Microsoft.CodeAnalysis;
 
 namespace DotNETDepends
 {
@@ -21,10 +16,8 @@ namespace DotNETDepends
         public readonly String FilePath;
         public readonly EntryType Type;
         public HashSet<ISymbol> Symbols = new(SymbolEqualityComparer.Default);
-       //This is the Roslyn semantic model.  Only valid if Type == File.  
-        public SemanticModel? Semantic { get; set; }
-        //SyntaxTree of a C# or VB file.  Comes from Roslyn.
-        public SyntaxTree? Tree { get; set; }
+        private readonly HashSet<string> References = new();
+
         //File dependencies of the file
         public HashSet<string> Dependencies { get; } = new HashSet<string>();
 
@@ -32,17 +25,32 @@ namespace DotNETDepends
         {
             FilePath = filePath;
             Type = type;
-            
+
+        }
+
+        public void AddReference(ISymbol symbol)
+        {
+            //ToDisplayString formats the symbol as <namespace>.<typeName>
+            //stringifying this helps with the lookup, as we can't use a 
+            //HashSet<ISymbol>::Contains to look them up
+            References.Add(symbol.ToDisplayString());
+        }
+
+        public bool ReferencesSymbol(ISymbol symbol)
+        {
+            //ToDisplayString formats the symbol as <namespace>.<typeName>
+            var synName = symbol.ToDisplayString();
+            return References.Contains(synName);
         }
 
         public void AddDependency(string dependency)
         {
-            if(dependency != FilePath)
+            if (dependency != FilePath)
             {
                 Dependencies.Add(dependency);
             }
         }
 
-        
+
     }
 }

--- a/DotNETDepends/Properties/launchSettings.json
+++ b/DotNETDepends/Properties/launchSettings.json
@@ -2,7 +2,7 @@
   "profiles": {
     "DotNETDepends": {
       "commandName": "Project",
-      "commandLineArgs": "\"C:\\Users\\Marcus\\projects\\With Space\\NetCoreMVC\\NetCoreMVC.sln\""
+      "commandLineArgs": "\"C:\\Users\\Marcus\\projects\\AspNetWebStack\\Runtime.sln\""
     }
   }
 }

--- a/TestDependencyReading/DependencyReaderTests.cs
+++ b/TestDependencyReading/DependencyReaderTests.cs
@@ -53,9 +53,12 @@ namespace TestDependencyReading
             SolutionReader reader = new();
             await reader.ReadSolutionAsync(slnFile, output).ConfigureAwait(false);
             Assert.IsNotNull(output);
-            Assert.AreEqual(2, output.Links.Length);
+            Assert.AreEqual(3, output.Links.Length);
             AssertLinks(new Dictionary<string, string>
             {
+                { FixPath("NetCoreMVC.sln"),
+                  FixPath("NetCoreMVC\\NetCoreMVC.csproj")
+                },
                 { FixPath("NetCoreMVC\\Controllers\\HomeController.cs"),
                   FixPath("NetCoreMVC\\Models\\ErrorViewModel.cs")
                 },
@@ -73,30 +76,41 @@ namespace TestDependencyReading
             SolutionReader reader = new();
             await reader.ReadSolutionAsync(slnFile, output).ConfigureAwait(false);
             Assert.IsNotNull(output);
-            Assert.AreEqual(3, output.Links.Length);
+            Assert.AreEqual(5, output.Links.Length);
 
             int matches = 0;
             foreach (var link in output.Links)
             {
+                if (LinkMatches("WinFormsApp1.sln", "WinFormsApp1\\WinFormsApp1.vbproj", link))
+                {
+                    matches++;
+                    continue;
+                }
                 if (LinkMatches("WinFormsApp1\\Form1.vb", "WinFormsApp1\\DoSomething.vb", link))
                 {
                     matches++;
                     continue;
                 }
-                if (LinkMatches("WinFormsApp1\\My Project\\Application.Designer.vb",
+                if (LinkMatches("WinFormsApp1\\Form1.Designer.vb",
+                "WinFormsApp1\\Form1.vb", link))
+                {
+                    matches++;
+                    continue;
+                }
+                if (LinkMatches("WinFormsApp1\\Form1.vb",
                 "WinFormsApp1\\Form1.Designer.vb", link))
                 {
                     matches++;
                     continue;
                 }
                 if (LinkMatches("WinFormsApp1\\My Project\\Application.Designer.vb",
-                "WinFormsApp1\\Form1.vb", link))
+                "WinFormsApp1\\ApplicationEvents.vb", link))
                 {
                     matches++;
                     continue;
                 }
             }
-            Assert.AreEqual(3, matches);
+            Assert.AreEqual(5, matches);
         }
 
         [TestMethod]
@@ -107,10 +121,15 @@ namespace TestDependencyReading
             SolutionReader reader = new();
             await reader.ReadSolutionAsync(slnFile, output).ConfigureAwait(false);
             Assert.IsNotNull(output);
-            Assert.AreEqual(3, output.Links.Length);
+            Assert.AreEqual(6, output.Links.Length);
             int matches = 0;
             foreach (var link in output.Links)
             {
+                if (LinkMatches("CSharpWinApp.sln", "CSharpWinApp\\CSharpWinApp.csproj", link))
+                {
+                    matches++;
+                    continue;
+                }
                 if (LinkMatches("CSharpWinApp\\Form1.cs", "CSharpWinApp\\DoSomething.cs", link))
                 {
                     matches++;
@@ -128,8 +147,22 @@ namespace TestDependencyReading
                     matches++;
                     continue;
                 }
+                //These are both partial classes
+                if (LinkMatches("CSharpWinApp\\Form1.cs",
+                "CSharpWinApp\\Form1.Designer.cs", link))
+                {
+                    matches++;
+                    continue;
+                }
+                //These are both partial classes
+                if (LinkMatches("CSharpWinApp\\Form1.Designer.cs",
+                "CSharpWinApp\\Form1.cs", link))
+                {
+                    matches++;
+                    continue;
+                }
             }
-            Assert.AreEqual(3, matches); ;
+            Assert.AreEqual(6, matches); ;
 
         }
 


### PR DESCRIPTION
## What changed
Added our own reference detection and resolution.  Started removing projects form the in memory solution once we process them.  Added links from the solution to the projects.  Added links between partial classes.


## Why are we making this change
A customer with a large codebase was unable to get a map to generate (tool would hang due to memory).


## How was the change implemented, and why was it implemented in this way
I found removing projects from the solution could allow them to be GCed.  If we do this though, Rosyln is unable to locate symbols properly (even if removed in dependency order).  To work around this, I added code to the AST visitor to just collect references ourselves.  Once we have these, we can safely close the project, and free the memory it held from compilation, parsing, etc.

## How was the change tested
Existing unit tests, but mainly against the .NET ASP core runtime.  That repo has dozens of projects and 2890 code files total.  Release mode runs in under 400MB, and in just under 1 minute.


## Screenshots of any frontend changes