### PR TITLE
ENG-2603 Make sure the output path exists.

### DIFF
--- a/DotNETDepends/PublishedWebProject.cs
+++ b/DotNETDepends/PublishedWebProject.cs
@@ -110,26 +110,29 @@ namespace DotNETDepends
             if (project.FilePath != null && assemblyName != null)
             {
                 var binRoot = Path.Combine(new string[] { Path.GetDirectoryName(project.FilePath)?? "", "bin", config });
-                DirectoryInfo dirInfo = new(binRoot);
-                var dirs = dirInfo.GetDirectories();
-                string? assemPath = null;
-                if (dirs.Length == 1)
+                if (Path.Exists(binRoot))
                 {
-                    assemPath = Path.Combine(new string[] { binRoot, dirs[0].Name, runtime, "publish", assemblyName });
-                    if (File.Exists(assemPath))
+                    DirectoryInfo dirInfo = new(binRoot);
+                    var dirs = dirInfo.GetDirectories();
+                    string? assemPath = null;
+                    if (dirs.Length == 1)
+                    {
+                        assemPath = Path.Combine(new string[] { binRoot, dirs[0].Name, runtime, "publish", assemblyName });
+                        if (File.Exists(assemPath))
+                        {
+                            return assemPath;
+                        }
+                        assemPath = Path.Combine(new string[] { binRoot, dirs[0].Name, runtime, assemblyName });
+                        if (File.Exists(assemPath))
+                        {
+                            return assemPath;
+                        }
+                        assemPath = Path.Combine(new string[] { binRoot, dirs[0].Name, assemblyName });
+                    }
+                    if (assemPath != null && File.Exists(assemPath))
                     {
                         return assemPath;
                     }
-                    assemPath = Path.Combine(new string[] { binRoot, dirs[0].Name, runtime, assemblyName });
-                    if (File.Exists(assemPath))
-                    {
-                        return assemPath;
-                    }
-                    assemPath = Path.Combine(new string[] { binRoot, dirs[0].Name, assemblyName });
-                }
-                if (assemPath != null && File.Exists(assemPath))
-                {
-                    return assemPath;
                 }
             }
             return null;


### PR DESCRIPTION
## What changed
Just make sure the output directory exists before try to enumerate it.


## Why are we making this change
.NET 5 puts the output in a different structure, and .NET 7 throws if you enumerate on a non-existent directory.


## How was the change implemented, and why was it implemented in this way
Just a Path.Exists check.  Further discussion could happen on .NET 5 support, but this is just for the crash.  Users will still get CSharp dependencies, but not for cshtml or vbhtml files with .NET 5.


## How was the change tested
Unit tests.


## Screenshots of any frontend changes
NA